### PR TITLE
docs: Add a README File

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # .github
-A repository for default community health files
+
+This repository contains the default community health files at Cartesian.
+
+## Important Notice
+
+Due to GitHub limitations, this is a public repository. Please take special care when pushing code into this repo, making notes in PRs and Issues, etc., as these are all public.
+
+Do not leak secret information through this repository; watch your language. 😉
+
+## Guidance
+
+Documentation on what can be placed in this repository is available [here](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file).


### PR DESCRIPTION
This PR adds a general README file to the repo, explaining its purpose and reminding everyone that this is a public repo.

Relates to #1.