### PR TITLE
build: Manage PNPM version in package.json

### DIFF
--- a/.github/workflows/check-formatting.yaml
+++ b/.github/workflows/check-formatting.yaml
@@ -12,10 +12,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Get PNPM version from package.json
+        id: pnpm-version
+        shell: bash
+        run: echo "pnpm_version=$(jq -r '.engines.pnpm' ./package.json)" >> $GITHUB_OUTPUT
+
       - name: Install PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: ${{ steps.pnpm-version.outputs.pnpm_version }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "format:check": "prettier --check .",
     "format:write": "prettier --write ."
   },
+  "engines": {
+    "pnpm": "^9.0.0"
+  },
   "dependencies": {
     "prettier": "^3.2.5"
   }


### PR DESCRIPTION
### Description

This PR moves the location of the PNPM version spec from the GitHub action into `package.json`.

### Related Issues

N/A

